### PR TITLE
Correct psql command to perform restore

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -134,7 +134,7 @@ if [ -n "\${MINIO_HOST}" ]; then
 	export RESTIC_REPOSITORY=s3:${MINIO_HOST_URL}/${MINIO_BUCKET}restic
 fi
 echo "=> Restore database from \$1"
-if psql -h${POSTGRES_HOST} -P${MYSQL_PORT} -U${POSTGRES_USER} < \$1 ;then
+if psql -h${POSTGRES_HOST} -p${POSTGRES_PORT} -U${POSTGRES_USER} < \$1 ;then
     echo "   Restore succeeded"
 else
     echo "   Restore failed"


### PR DESCRIPTION
According to the psql documentation
-p is for the port , not -P
And the passed variable was wrong.
Must be POSTGRES_PORT instead of MYSQL_PORT